### PR TITLE
Allow other options to be passed on the CLI

### DIFF
--- a/src/MoteRunner/Options.purs
+++ b/src/MoteRunner/Options.purs
@@ -15,7 +15,7 @@ type Config =
 
 parseConfig ∷ Effect (Either String Config)
 parseConfig = do
-  { value } ← optlicate {} (defaultPreferences { globalOpts = parseConfig' })
+  { value } ← optlicate {} (defaultPreferences { globalOpts = parseConfig', errorOnUnrecognizedOpts = false })
   pure $ unV (Left <<< renderErrors) Right value
 
 parseConfig' :: Optlicative Config


### PR DESCRIPTION
This means the main for the tests can make use of other options that might be present too (like, for us, overriding the launcher arguments used in the tests).