### PR TITLE
Update dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,15 +10,19 @@
   "dependencies": {
     "purescript-prelude": "^4.0.0",
     "purescript-console": "^4.1.0",
-    "purescript-optlicative": "^5.0.0",
+    "purescript-optlicative": "^6.0.0",
     "purescript-validation": "^4.0.0",
-    "purescript-node-process": "^6.0.0",
-    "purescript-record": "^1.0.0",
+    "purescript-node-process": "^7.0.0",
+    "purescript-record": "^2.0.0",
     "purescript-mote": "^1.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
     "purescript-test-unit": "^14.0.0",
     "purescript-node-fs-aff": "^6.0.0"
+  },
+  "resolutions": {
+    "purescript-record": "^2.0.0",
+    "purescript-typelevel-prelude": "^4.0.0"
   }
 }


### PR DESCRIPTION
The resolutions are required for the `devDependencies` only - it's caused by `purescript-test-unit`